### PR TITLE
It's necessary to install the RubyGem 'thinking-sphinx'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -199,4 +199,6 @@ group :demo do
 
   # Exceptions
   #gem 'airbrake'
+  # Install App for Searching
+  gem 'thinking-sphinx'
 end


### PR DESCRIPTION
for doing `bundle exec rake ts:rebuild`，It's necessary to install the RubyGem 'thinking-sphinx'
