### PR TITLE
test(travis): use non-sudo mode to enable faster CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 before_script:
   - psql -c 'create database bookyt_test' -U postgres
   - bundle exec rake bookyt:travis


### PR DESCRIPTION
Travis now uses Docker based containers with massive build speedups. It
is enabled when declaring not to use SUDO.

This patch configures travis not to require sudo.