### PR TITLE
chores(ci): enable bundler caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 
+language: ruby
+cache: bundler
+
 before_script:
   - psql -c 'create database bookyt_test' -U postgres
   - bundle exec rake bookyt:travis


### PR DESCRIPTION
Installing the gems takes some time on Travis. We can enable bundler
caching to speed it up.

This patch adds the .travis.yml config to enable gem caching.

See: http://docs.travis-ci.com/user/caching/