### PR TITLE
feat(capistrano): re-add capistrano for deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,8 @@
+require 'bundler/setup'
+
+load 'deploy' if respond_to?(:namespace) # cap2 differentiator
+
+Dir['vendor/plugins/*/recipes/*.rb'].each { |plugin| load(plugin) }
+Dir['lib/recipes/*.rb'].each { |plugin| load(plugin) }
+
+load 'config/deploy' # remove this line to skip loading any of the default tasks

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,9 @@ group :development do
   gem 'rdoc'
 
   gem 'quiet_assets'
+
+  # Deployment
+  gem 'capones_recipes'
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,21 @@ GEM
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
     cancancan (1.10.1)
+    cap-recipes (0.3.39)
+    capistrano (2.15.5)
+      highline
+      net-scp (>= 1.0.0)
+      net-sftp (>= 2.0.0)
+      net-ssh (>= 2.0.14)
+      net-ssh-gateway (>= 1.1.0)
+    capistrano-ext (1.2.1)
+      capistrano (>= 1.0.0)
+    capistrano_colors (0.5.5)
+    capones_recipes (1.20.1)
+      cap-recipes
+      capistrano (~> 2.0)
+      capistrano-ext
+      capistrano_colors
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -174,6 +189,7 @@ GEM
       simple_form
     hashery (2.1.1)
     hashie (3.4.0)
+    highline (1.7.2)
     hike (1.2.3)
     i18n (0.7.0)
     i18n_rails_helpers (2.0.0)
@@ -210,6 +226,13 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth2 (1.0.0)
@@ -429,6 +452,7 @@ DEPENDENCIES
   bootstrap-datepicker-rails
   bootstrap-will_paginate
   cancancan
+  capones_recipes
   capybara
   carrierwave
   coffee-rails

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,44 @@
+# Application
+set :application, 'bookyt'
+set :repository,  'git@github.com:huerlisi/bookyt.git'
+
+require 'capones_recipes/cookbook/rails'
+require 'capones_recipes/tasks/settings_logic'
+require 'capones_recipes/tasks/database/setup'
+require 'capones_recipes/tasks/email'
+require 'capones_recipes/tasks/carrier_wave'
+require 'capones_recipes/tasks/sync'
+require 'capones_recipes/tasks/bluepill'
+
+load 'deploy/assets'
+
+# Staging
+set :default_stage, 'staging'
+
+# Deployment
+set :user, "deployer"                               # The server's user for deploys
+
+# Sync directories
+set :sync_directories, ['uploads']
+set :sync_backups, 3
+
+# Configuration
+set :scm, :git
+ssh_options[:forward_agent] = true
+set :use_sudo, false
+set :deploy_via, :remote_cache
+set :git_enable_submodules, 1
+set :copy_exclude, [".git", "spec"]
+
+# Dependencies
+depend :remote, :gem, 'bundler', '> 0'
+depend :remote, :gem, 'bluepill', ''
+
+# Headers for gem compilation
+depend :remote, :deb, "build-essential", ''
+depend :remote, :deb, "ruby1.9.1-dev", ''
+depend :remote, :deb, "libmysqlclient-dev", ''
+depend :remote, :deb, "libsqlite3-dev", ''
+depend :remote, :deb, "libxml2-dev", ''
+depend :remote, :deb, "libxslt1-dev", ''
+depend :remote, :deb, "sphinxsearch", ''

--- a/config/deploy/bluepill.rb.erb
+++ b/config/deploy/bluepill.rb.erb
@@ -1,0 +1,42 @@
+application = "<%= instance %>"
+environment = "<%= rails_env %>"
+shared_dir  = "<%= shared_path %>"
+current_dir = "<%= current_path %>"
+
+ENV["RAILS_ENV"] = environment
+
+Bluepill.application(application, :log_file => "#{shared_dir}/log/bluepill.log") do |app|
+  app.working_dir = current_dir
+
+  app.process("#{application}: unicorn") do |process|
+    process.pid_file = "#{shared_dir}/pids/unicorn.pid"
+
+    process.start_command = "/usr/local/bin/bundle exec unicorn -c #{current_dir}/config/unicorn.rb -E #{environment} -D"
+    process.stop_command = "kill -QUIT {{PID}}"
+    process.restart_command = "kill -USR2 {{PID}}"
+
+    process.start_grace_time = 30.seconds
+    process.stop_grace_time = 30.seconds
+    process.restart_grace_time = 30.seconds
+
+
+    process.monitor_children do |child_process|
+      child_process.stop_command = "kill -QUIT {{PID}}"
+
+      child_process.checks :mem_usage, :every => 30.seconds, :below => 200.megabytes, :times => [3,4], :fires => :stop
+      child_process.checks :cpu_usage, :every => 30.seconds, :below => 40, :times => [3,4], :fires => :stop
+    end
+  end
+
+  app.process("#{application}: sphinx") do |process|
+    process.pid_file = "#{shared_dir}/pids/searchd.#{environment}.pid"
+
+    process.start_command = "/usr/local/bin/bundle exec rake ts:start"
+
+    process.start_grace_time = 30.seconds
+    process.stop_grace_time = 30.seconds
+    process.restart_grace_time = 30.seconds
+  end
+end
+
+

--- a/config/deploy/database.yml.erb
+++ b/config/deploy/database.yml.erb
@@ -1,0 +1,39 @@
+# Database configuration
+# ======================
+# This file can be use as a template for the database.yml file.
+#
+# If you're using the SQLite3 file-based database, all you have
+# to do is copy this file to database.yml.
+#
+# While you may use the SQLite3 database, it has some issues
+# with date handling. It's sometimes giving strange amounts
+# in account views for opening balance etc.
+#
+# For production environments MySQL is a better fit. In this
+# case you need to setup the databases and adapt this file:
+#
+# 1. create the database and grant access
+# 3. set username and password and possibly host settings in
+#    the environment config.
+
+# Common settings
+# ===============
+# SQLite3
+sqlite: &sqlite
+  adapter: sqlite3
+  pool:    5
+  timeout: 5000
+
+# MySQL
+mysql: &mysql
+  adapter:  mysql2
+  encoding: utf8
+
+# Environments
+# ============
+<%= rails_env %>:
+  <<: *mysql
+  host:     <%= db_host %>
+  database: <%= db_database %>
+  username: <%= db_username %>
+  password: <%= db_password %>


### PR DESCRIPTION
We used capistrano with our own capones-recipes extensions to deploy
Bookyt. Capones-recipes allows to hold deployment stages in another
repository, a feature we (CyT) uses actively. It also provides some nice
helpers to sync all data from a deployment down and so on.

The capones-recipes gem did not get much love though, and is therefore a
bit outdated and misses docs. For that reason it was dropped in the last
round of gem updates. We need to do deployments though, and therefore
add it back for now.

This commit add all the files back that are needed to do capistrano
deployments beside actual deployment specifications.