### PR TITLE
fix(user): build associated person on demand

### DIFF
--- a/app/controllers/tenants_controller.rb
+++ b/app/controllers/tenants_controller.rb
@@ -10,8 +10,6 @@ class TenantsController < AuthorizedController
 
   private
   def prepare_sheet
-    @company = current_tenant.company
-
     # use current date if not specified otherwise
     if params[:by_date]
       # TODO: check on :to and :from to not be nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,11 +39,6 @@ class User < ActiveRecord::Base
     super || build_person
   end
 
-  # Shortcuts
-  def current_company
-    person.try(:employers).try(:first)
-  end
-
   # Locale
   attr_accessible :locale
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,10 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :person
   attr_accessible :person, :person_id, :person_attributes
 
+  def person
+    super || build_person
+  end
+
   # Shortcuts
   def current_company
     person.try(:employers).try(:first)

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -12,7 +12,6 @@
   .row-fluid
     .span6= f.input :role_texts, :as => :select, :collection => Ability.roles_for_collection, :include_blank => false, :input_html => {:multiple => 'multiple', :class => 'span select2'}, :required => true if can?(:manage, Role)
 
-  - f.object.build_person unless f.object.person
   %h3= t('form.person.address')
   = f.fields_for :person do |p|
     = render 'has_vcards/vcards/form', :f => p, :full_vcard => true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ describe User do
   describe "when new" do
     specify { is_expected.not_to be_valid }
     its(:to_s) { should == "" }
-    its(:current_company) { should be_nil }
+    its(:person) { should be_present }
   end
 
   describe "as admin" do


### PR DESCRIPTION
We do attach a Person object (including Vcard etc.) to Users. We use
this information when building Debit Invoices. The User#person
object is not created on User creation, but should be built on demand.

This patch builds a new, associated person on Users objects if needed.