### PR TITLE
Improve printing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ gem 'ledermann-rails-settings'
 # ======
 # Accounting
 gem 'has_accounts'
-gem 'has_accounts_engine', '3.0.0.beta11'
+gem 'has_accounts_engine', '3.0.0.beta12'
 
 # Addresses
 gem 'has_vcards'

--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ gem 'ledermann-rails-settings'
 # ======
 # Accounting
 gem 'has_accounts'
-gem 'has_accounts_engine', '3.0.0.beta10'
+gem 'has_accounts_engine', '3.0.0.beta11'
 
 # Addresses
 gem 'has_vcards'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     has_accounts (3.0.0.beta1)
       rails (~> 3.1)
       validates_timeliness
-    has_accounts_engine (3.0.0.beta10)
+    has_accounts_engine (3.0.0.beta11)
       acts-as-taggable-on
       anjlab-bootstrap-rails (~> 2.1.0)
       has_accounts (~> 3.0.0.beta0)
@@ -465,7 +465,7 @@ DEPENDENCIES
   faraday
   haml-rails
   has_accounts
-  has_accounts_engine (= 3.0.0.beta10)
+  has_accounts_engine (= 3.0.0.beta11)
   has_scope
   has_vcards
   i18n_rails_helpers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     has_accounts (3.0.0.beta1)
       rails (~> 3.1)
       validates_timeliness
-    has_accounts_engine (3.0.0.beta11)
+    has_accounts_engine (3.0.0.beta12)
       acts-as-taggable-on
       anjlab-bootstrap-rails (~> 2.1.0)
       has_accounts (~> 3.0.0.beta0)
@@ -465,7 +465,7 @@ DEPENDENCIES
   faraday
   haml-rails
   has_accounts
-  has_accounts_engine (= 3.0.0.beta11)
+  has_accounts_engine (= 3.0.0.beta12)
   has_scope
   has_vcards
   i18n_rails_helpers

--- a/app/assets/stylesheets/partials/print/_layout.sass
+++ b/app/assets/stylesheets/partials/print/_layout.sass
@@ -1,26 +1,32 @@
 // Media print specific styles ****
 
+body
+  padding-top: 0
+  font-size: 10pt
+  line-height: 1.2
+
+.page-header
+  margin: 0
+  padding: 0
+
+h1
+  font-size: 14pt
+
+
 // Navigation elements
 .navbar,
 #sidebar,
 .pagination,
 .search-form,
-#footer
+#footer,
+.form-actions
   display: none
 
 // Sidebar fix
-.row-fluid
-  width: 150%
-.row-fluid .row-fluid
+#content > .row-fluid > .span10
   width: 100%
-
-.tab-content
-  table
-    width: 60%
-
-// Content
-.container-fluid .content
-  margin-right: 20px
+  padding: 0
+  margin: 0
 
 // Alerts
 .alert
@@ -45,8 +51,7 @@ ul.nav.nav-tabs li
   a
     border:      none
     outline:     none
-    font-size:   24px
-    line-height: 36px
+    font-size:   12pt
     color:       #333
     font-weight: bold
     margin:      0
@@ -64,3 +69,31 @@ select
 
 .ui-widget-content
   border: none
+
+form
+  .container-fluid
+    padding-left: 0
+    padding-right: 0
+
+.form-horizontal
+  .control-group
+    margin-bottom: 0
+
+    label
+      width: auto
+      margin-bottom: 0
+
+    .controls
+      margin-left: 0
+      input
+        border-style: none
+        border-bottom-style: solid
+        border-radius: 0
+        box-shadow: none
+        -webkit-box-shadow: none
+        outline-style: none
+        padding: 0
+
+tbody tr.selected td, .table-striped tbody tr.selected td
+  background-color: #f9f9f9
+  border-color: #ddd

--- a/doc/README_FOR_APP
+++ b/doc/README_FOR_APP
@@ -1,2 +1,0 @@
-Use this README file to introduce your application and point to useful places in the API for learning more.
-Run "rake doc:app" to generate API documentation for your models, controllers, helpers, and libraries.


### PR DESCRIPTION
We had suboptimal printing support. This patch improves printing by

* reducing the font size
* use full with of the page
* hide form controls
* nicely show filter rules
* use proper heading sizes
* hide booking selections

It should work in both browser printing dialogs and on PDF server side
rendering.

Update has_accounts_engine to get support for printing buttons in
account view and bookings journal.

NOTE: the bookings print view does not yet show the proper parameters
due to AJAX not updating the printing URL.

Fixes #70 