### PR TITLE
only validate line item times for non saldo line items

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -12,7 +12,7 @@ class LineItem < ActiveRecord::Base
 
   # Validations
   validates :invoice, :presence => true
-  validates :times, :presence => true, :numericality => true
+  validates :times, :presence => true, :numericality => true, :unless => :is_a_saldo_line_item?
   validates :price, :presence => true, :numericality => true
   validates :title, :presence => true
 
@@ -130,8 +130,10 @@ class LineItem < ActiveRecord::Base
   # Booking templates
   belongs_to :booking_template
 
-  before_save :set_type
-private
+  before_validation :set_type
+
+  private
+
   def set_type
     if self.quantity == 'saldo_of'
       self.type = "SaldoLineItem"
@@ -139,4 +141,9 @@ private
       self.type = "LineItem"
     end
   end
+
+  def is_a_saldo_line_item?
+    self.type == "SaldoLineItem"
+  end
+
 end


### PR DESCRIPTION
We had issues with saving invoices with saldo or summary items. This also affects all invoices with VAT.

Thanks go to @silvermind for noticing and fixing this as part of #69 