### PR TITLE
fix(invoices): set default title for new subtotal line items

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -20,7 +20,9 @@ class InvoicesController < AuthorizedController
 
     case params[:klass]
     when 'SaldoLineItem'
-      @line_item = SaldoLineItem.new
+      @line_item = SaldoLineItem.new(
+        :title => t('saldo_line_item', :scope => 'activerecord.models')
+      )
     else
       @line_item = LineItem.new(
         :times          => 1,

--- a/config/locales/bookyt.de.yml
+++ b/config/locales/bookyt.de.yml
@@ -185,6 +185,7 @@ de:
       expense: Ausgabe
       invoice: Rechnung
       line_item: Position
+      saldo_line_item: Zwischentotal
       booking_import_attachment: Bankdaten
       mt940_import: MT940 Bankdaten
       note: Notizen

--- a/config/locales/bookyt.en.yml
+++ b/config/locales/bookyt.en.yml
@@ -225,6 +225,7 @@ en:
       expense: Expense
       invoice: Invoice
       line_item: "Line Item"
+      saldo_line_item: "Subtotal"
       note: Note
       overview: Overview
       person: Person


### PR DESCRIPTION
We currently do not assign a title, and this will even trigger a form
validation error. And the missing field is not even visually marked.
This makes this one quite nasty.

This patch sets a default title.

Fixes #76 