### PR TITLE
feat(invoices): improve usability of line item form

### DIFF
--- a/app/assets/javascripts/cyt.js
+++ b/app/assets/javascripts/cyt.js
@@ -1,7 +1,8 @@
 // Combobox
 function addComboboxBehaviour() {
   $("select.combobox").select2({
-    allowClear: true
+    allowClear: true,
+    width: 'resolve'
   });
 }
 

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -15,6 +15,8 @@ class LineItem < ActiveRecord::Base
   validates :times, :presence => true, :numericality => true, :unless => :is_a_saldo_line_item?
   validates :price, :presence => true, :numericality => true
   validates :title, :presence => true
+  validates :credit_account, :presence => true
+  validates :debit_account, :presence => true
 
   # String
   def to_s

--- a/app/views/line_items/_form.html.haml
+++ b/app/views/line_items/_form.html.haml
@@ -1,12 +1,12 @@
 %tr.nested-form-item[line_item.object]
-  %td= line_item.text_field :date, :style => 'width: 85px', 'date-picker' => 'true'
-  %td= line_item.text_field :title, :required => true, :style => 'width: 30em'
-  %td= line_item.text_field :times, :required => true, :style => 'width: 3em', :autocomplete => "off"
-  %td= line_item.select :quantity, ['x', 'hours', 'overall', '%'].map{|quantity| [t(quantity, :scope => 'line_items.quantity'), quantity]}, {}, :style => 'width: 6em'
-  %td= line_item.text_field :price, :required => true, :style => 'width: 5em', :autocomplete => "off"
+  %td= line_item.input :date, as: :date_field, :input_html => {:style => 'width: 6em'}
+  %td= line_item.input :title, :input_html => {:style => 'width: 20em'}
+  %td= line_item.input :times, :input_html => {:style => 'width: 4em', :autocomplete => "off"}
+  %td= line_item.input :quantity, :collection => ['x', 'hours', 'overall', '%'].map{|quantity| [t(quantity, :scope => 'line_items.quantity'), quantity]}, :input_html => {:style => 'width: 4em'}
+  %td= line_item.input :price, :input_html => {:style => 'width: 5em', :autocomplete => "off"}
   %td.currency.total_amount= currency_fmt(line_item.object.accounted_amount)
-  %td= line_item.select :debit_account_id, accounts_as_collection(Account.all), {:include_blank => true}, :class => 'combobox span'
-  %td= line_item.select :credit_account_id, accounts_as_collection(Account.all), {:include_blank => true}, :class => 'combobox span'
+  %td= line_item.association :debit_account, :as => :combobox, :label_method => lambda {|option| option.to_s(:select)}, :input_html => {:style => 'width: 7em; max-width: 9em'}
+  %td= line_item.association :credit_account, :as => :combobox, :label_method => lambda {|option| option.to_s(:select)}, :input_html => {:style => 'width: 7em; max-width: 9em'}
   %td.action_links
     = line_item.hidden_field :position
     = line_item.hidden_field :code

--- a/app/views/line_items/_list_form.html.haml
+++ b/app/views/line_items/_list_form.html.haml
@@ -3,7 +3,7 @@
   %thead
     = render 'line_items/list_header', :invoice => invoice
   %tbody.sortable
-    = f.simple_fields_for :line_items do |line_item|
+    = f.simple_fields_for :line_items, :wrapper => :inline do |line_item|
       = render "#{line_item.object.class.name.underscore.pluralize}/form", :line_item => line_item
   %tfoot
     = render 'line_items/list_footer', :total_amount => invoice.amount

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -74,16 +74,17 @@ SimpleForm.setup do |config|
       input.wrapper :tag => 'div', :class => 'input-prepend' do |prepend|
         prepend.use :input
       end
-      input.use :hint,  :wrap_with => { :tag => 'span', :class => 'help-block' }
-      input.use :error, :wrap_with => { :tag => 'span', :class => 'help-inline' }
+      input.use :hint,  :wrap_with => { :tag => 'span', :class => 'help-inline' }
+      input.use :error, :wrap_with => { :tag => 'span', :class => 'help-block' }
     end
   end
 
-  config.wrappers :inline, :tag => 'span', :error_class => 'error' do |b|
+  config.wrappers :inline, :tag => 'span', :class => "control-group", :error_class => 'error' do |b|
     b.use :html5
     b.use :placeholder
     b.use :input
     b.use :hint,  :wrap_with => { :tag => 'p', :class => 'help-block' }
+    b.use :error, :wrap_with => { :tag => 'p', :class => 'help-block' }
   end
 
   config.wrappers :append, :tag => 'div', :class => "control-group", :error_class => 'error' do |b|


### PR DESCRIPTION
The line item form in invoices had some major usability issues:
* too much horizontal space needed
* no validation
* no date formating

Fixes #78, #77 