### PR TITLE
Use a specific account to book losses

### DIFF
--- a/app/models/debit_invoice.rb
+++ b/app/models/debit_invoice.rb
@@ -16,6 +16,10 @@ class DebitInvoice < Invoice
       Account.tagged_with('invoice:payment').first
   end
 
+  def self.write_off_account
+    Account.find_by_tag('invoice:write_off')
+  end
+
   def self.available_credit_accounts
     Account.by_type('current_assets')
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -171,6 +171,10 @@ class Invoice < ActiveRecord::Base
     self.class.profit_account
   end
 
+  def write_off_account
+    self.class.write_off_account
+  end
+
   def direct_account_factor
     # Guard
     return 1 unless direct_account

--- a/app/models/invoice/actions.rb
+++ b/app/models/invoice/actions.rb
@@ -19,23 +19,23 @@ module Invoice::Actions
                        :value_date => Date.today)
       end
     end
-    
+
     self.state = 'reactivated'
 
     for session in sessions
       session.reactivate
     end
-    
+
     return self
   end
-  
+
   def write_off(comments = nil)
     if balance > 0
-      bookings.build(:title => "Debitorenverlust",
+      bookings.create!(:title => "Debitorenverlust",
                      :comments => comments || "Abgeschrieben",
                      :amount => balance,
-                     :credit_account => profit_account,
-                     :debit_account => balance_account,
+                     :credit_account => balance_account,
+                     :debit_account => write_off_account,
                      :value_date => Date.today)
     end
 


### PR DESCRIPTION
This allows one to assign the tag `invoice:write_off` to an account to allow writing off an invoice.