### PR TITLE
support specifying a reference invoice when creating bookings via API

### DIFF
--- a/app/api/bookyt/api/bookings.rb
+++ b/app/api/bookyt/api/bookings.rb
@@ -16,6 +16,7 @@ module Bookyt
           requires :credit_account_tag, type: String, desc: 'Tag of the credit account'
           requires :debit_account_tag, type: String, desc: 'Tag of the debit account'
           optional :comments, type: String, desc: 'Additional comments'
+          optional :invoice_id, type: Fixnum, desc: 'ID of invoice to reference'
         end
         post do
           begin
@@ -29,6 +30,7 @@ module Bookyt
               debit_account: debit_account,
               comments: params[:comments],
             }
+            attributes.merge!(reference: Invoice.find(params[:invoice_id])) if params[:invoice_id]
             booking = Booking.create!(attributes)
             present booking, with: Bookyt::Entities::Booking
           rescue Account::AmbiguousTag => error
@@ -51,6 +53,7 @@ module Bookyt
             requires :credit_account_tag, type: String, desc: 'Tag of the credit account'
             requires :debit_account_tag, type: String, desc: 'Tag of the debit account'
             optional :comments, type: String, desc: 'Additional comments'
+            optional :invoice_id, type: Fixnum, desc: 'ID of invoice to reference'
           end
           put do
             begin
@@ -64,6 +67,7 @@ module Bookyt
                 debit_account: debit_account,
                 comments: params[:comments],
               }
+              attributes.merge!(reference: Invoice.find(params[:invoice_id])) if params[:invoice_id]
               booking = Booking.find(params[:id])
               booking.update_attributes!(attributes)
               present booking, with: Bookyt::Entities::Booking

--- a/app/api/bookyt/api/bookings.rb
+++ b/app/api/bookyt/api/bookings.rb
@@ -16,7 +16,7 @@ module Bookyt
           requires :credit_account_tag, type: String, desc: 'Tag of the credit account'
           requires :debit_account_tag, type: String, desc: 'Tag of the debit account'
           optional :comments, type: String, desc: 'Additional comments'
-          optional :invoice_id, type: Fixnum, desc: 'ID of invoice to reference'
+          optional :invoice_id, type: Fixnum, desc: 'ID of invoice to reference', values: -> { Invoice.pluck(:id) }
         end
         post do
           begin
@@ -53,7 +53,7 @@ module Bookyt
             requires :credit_account_tag, type: String, desc: 'Tag of the credit account'
             requires :debit_account_tag, type: String, desc: 'Tag of the debit account'
             optional :comments, type: String, desc: 'Additional comments'
-            optional :invoice_id, type: Fixnum, desc: 'ID of invoice to reference'
+            optional :invoice_id, type: Fixnum, desc: 'ID of invoice to reference', values: -> { Invoice.pluck(:id) }
           end
           put do
             begin

--- a/spec/api/bookyt/api/bookings_spec.rb
+++ b/spec/api/bookyt/api/bookings_spec.rb
@@ -60,6 +60,23 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
       it 'assigns the booking to the given invoice' do
         expect { post '/api/bookings', params, headers }.to change { invoice.bookings.count }.from(0).to(1)
       end
+
+      context 'invoice id does not exist' do
+        it 'validates presence of the invoice id' do
+          params[:invoice_id] = 'asd'
+          post '/api/bookings', params, headers
+          expect(JSON.parse(response.body)).to be_instance_of(Hash)
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context 'invoice id is nil' do
+        it 'does not care about a nil value' do
+          params[:invoice_id] = nil
+          post '/api/bookings', params, headers
+          expect(response.status).to eq(201)
+        end
+      end
     end
 
     context 'too many accounts found' do
@@ -136,6 +153,23 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
 
       it 'assigns the booking to the given invoice' do
         expect { post '/api/bookings', params, headers }.to change { invoice.bookings.count }.from(0).to(1)
+      end
+
+      context 'invoice id does not exist' do
+        it 'validates presence of the invoice id' do
+          params[:invoice_id] = 'asd'
+          put "/api/bookings/#{booking.id}", params, headers
+          expect(JSON.parse(response.body)).to be_instance_of(Hash)
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context 'invoice id is nil' do
+        it 'does not care about a nil value' do
+          params[:invoice_id] = nil
+          put "/api/bookings/#{booking.id}", params, headers
+          expect(response.status).to eq(200)
+        end
       end
     end
 

--- a/spec/api/bookyt/api/bookings_spec.rb
+++ b/spec/api/bookyt/api/bookings_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
   end
 
   describe 'POST /api/bookings' do
+    let(:invoice) { FactoryGirl.create(:debit_invoice) }
     let(:params) do
       {
         title: 'Test',
@@ -31,6 +32,7 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
         credit_account_tag: 'incoming:test:credit',
         debit_account_tag: 'incoming:test:debit',
         comments: 'This is a loooooooooooong comment',
+        invoice_id: invoice.id,
       }
     end
 
@@ -53,6 +55,10 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
       it 'uses Bookyt::Entities::Booking to display the created Booking' do
         expect(Bookyt::Entities::Booking).to receive(:represent)
         post '/api/bookings', params, headers
+      end
+
+      it 'assigns the booking to the given invoice' do
+        expect { post '/api/bookings', params, headers }.to change { invoice.bookings.count }.from(0).to(1)
       end
     end
 
@@ -93,6 +99,7 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
   end
 
   describe 'PUT /api/bookings/:id' do
+    let(:invoice) { FactoryGirl.create(:debit_invoice) }
     let(:params) do
       {
         title: 'Test',
@@ -101,6 +108,7 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
         credit_account_tag: 'incoming:test:credit',
         debit_account_tag: 'incoming:test:debit',
         comments: 'This is a loooooooooooong comment',
+        invoice_id: invoice.id,
       }
     end
     let!(:booking) { FactoryGirl.create :account_booking }
@@ -124,6 +132,10 @@ RSpec.describe Bookyt::API::Bookings, type: :request do
       it 'uses Bookyt::Entities::Booking to display the Booking' do
         expect(Bookyt::Entities::Booking).to receive(:represent)
         put "/api/bookings/#{booking.id}", params, headers
+      end
+
+      it 'assigns the booking to the given invoice' do
+        expect { post '/api/bookings', params, headers }.to change { invoice.bookings.count }.from(0).to(1)
       end
     end
 


### PR DESCRIPTION
Add `invoice_id` to API to support referencing an `Invoice` when creating or updating a `Booking`.