### PR TITLE
disable auto price calculation of line items w/o saldo line item

### DIFF
--- a/app/assets/javascripts/bookyt.js
+++ b/app/assets/javascripts/bookyt.js
@@ -39,7 +39,9 @@ function updateLineItemPrice(lineItem) {
   var list = lineItem.parent();
   var reference_code = lineItem.find(":input[name$='[reference_code]']").val();
   var quantity = lineItem.find(":input[name$='[quantity]']").val();
-  if (quantity == '%' || quantity == 'saldo_of') {
+  var after_saldo_line_item = lineItem.prev().hasClass('saldo_line_item')
+  var is_saldo_line_item = lineItem.hasClass('saldo_line_item')
+  if ((quantity == '%' || quantity == 'saldo_of') && (after_saldo_line_item || is_saldo_line_item)) {
     var included_items;
     if (reference_code == '') {
       included_items = lineItem.prevAll('.line_item');


### PR DESCRIPTION
This disables price auto calculation of items which are not directly after a saldo line item.
It allows you to create line items which have a price that does not match the total of all the preceeding line items.

![screenshot 2016-02-23 17 09 41](https://cloud.githubusercontent.com/assets/124441/13257827/acf3f6f6-da50-11e5-9789-08a25d7448e9.png)
