### PR TITLE
FIx for server unable to find db/seeds.rb

### DIFF
--- a/app/controllers/admin/tenants_controller.rb
+++ b/app/controllers/admin/tenants_controller.rb
@@ -35,7 +35,7 @@ class Admin::TenantsController < ApplicationController
     if @instance_tenant.valid? && @user.valid? && @tenant.save
       Apartment::Tenant.create(@tenant.db_name)
       Apartment::Tenant.switch(@tenant.db_name)
-      load "db/seeds.rb"
+      load "#{Rails.root}/db/seeds.rb"
 
       @instance_tenant.save!
       # Assign roles again, as we need to assign the roles in this db.


### PR DESCRIPTION
Sometimes on dev mode, rails application is unable to find the db/seeds.rb because it tries to find inside "/app/controllers/admin" folder. This will ensure loading from root path