### PR TITLE
ISSUE: Make sure CASExtraAttributesMapper defined by loading `lib/cas_extra_attributes_mapper`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,6 +83,7 @@ class CASExtraAttributesMapper
   end
 end
 ```
+**And this class must have to contained by the file named `cas_extra_attributes_mapper.rb` in `/lib` directory.**
 
 Setup admin user
 ----------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,6 +84,9 @@ class CASExtraAttributesMapper
 end
 ```
 **And this class must have to contained by the file named `cas_extra_attributes_mapper.rb` in `/lib` directory.**
+###### Why? 
+
+Because it has to map the user to a tenant
 
 Setup admin user
 ----------------

--- a/config/initializers/cas_authenticatable.rb
+++ b/config/initializers/cas_authenticatable.rb
@@ -1,0 +1,8 @@
+if Settings.devise_backend.to_sym == :cas_authenticatable
+  begin
+    require Rails.root.join('lib/cas_extra_attributes_mapper').to_s
+  rescue LoadError
+    fail 'Please add `cas_extra_attributes_mapper` file inside `/lib` and define class '\
+         '`CASExtraAttributesMapper` first to use `cas_authenticatable`'
+  end
+end


### PR DESCRIPTION
If `cas_authenticatable` activated it's required to define CASExtraAttributesMapper class. And it would be great if we store this class inside `lib/cas_extra_attributes_mapper`.

So, this fix will ensure that developer must have to load `lib/cas_extra_attributes_mapper` when server starts.

Thanks!